### PR TITLE
Install python paramiko as linux package.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,13 +47,13 @@ default['duplicity_ng']['source']['azure']['checksum'] = '68d87bffc4a719659ecd88
 
 case node['platform_family']
 when 'debian'
-  default['duplicity_ng']['source']['dev']['packages'] = %w(python-dev librsync-dev)
+  default['duplicity_ng']['source']['dev']['packages'] = %w(python-dev python-paramiko librsync-dev)
   default['duplicity_ng']['source']['azure']['packages'] = %w(libffi-dev)
-  default['duplicity_ng']['source']['python']['packages'] = %w(python-lockfile python-setuptools python-gnupginterface python-paramiko)
+  default['duplicity_ng']['source']['python']['packages'] = %w(python-lockfile python-setuptools python-gnupginterface)
 when 'rhel', 'fedora', 'suse'
   # Use pip by default on rhel, as the packages are outdated
   default['duplicity_ng']['use_pip'] = true
-  default['duplicity_ng']['source']['dev']['packages'] = %w(python-devel librsync-devel)
+  default['duplicity_ng']['source']['dev']['packages'] = %w(python-devel python-paramiko librsync-devel)
   default['duplicity_ng']['source']['azure']['packages'] = %w(libffi-devel)
-  default['duplicity_ng']['source']['python']['packages'] = %w(python-lockfile python-setuptools python-GnuPGInterface python-paramiko)
+  default['duplicity_ng']['source']['python']['packages'] = %w(python-lockfile python-setuptools python-GnuPGInterface)
 end


### PR DESCRIPTION
Install python paramiko as linux package. Because of its upgrade. 
Upgraded one not works with legacy python(2.6) via pip.